### PR TITLE
Adding Yarn as a devDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.6.0",
-    "jest": "^21.0.2"
+    "jest": "^21.0.2",
+    "yarn": "^1.3.2"
   },
   "dependencies": {
     "cross-env": "^5.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3023,3 +3023,7 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yarn@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.3.2.tgz#5939762581b5b4ddcd3418c0f6be42df3aee195f"


### PR DESCRIPTION
Yarn is used during development and is a requirement in the
`prepublishOnly` script. This commit allows for dev scripts to be
run, regardless of the presence of a global `yarn`.

Fixes #2